### PR TITLE
Dependency on mysql should be controlled by ACTIVATE_MYSQL

### DIFF
--- a/tutornotes/patches/local-docker-compose-jobs-services
+++ b/tutornotes/patches/local-docker-compose-jobs-services
@@ -4,5 +4,4 @@ notes-job:
     DJANGO_SETTINGS_MODULE: notesserver.settings.tutor
   volumes:
     - ../plugins/notes/apps/settings/tutor.py:/openedx/edx-notes-api/notesserver/settings/tutor.py:ro
-  depends_on:
-    - mysql
+  depends_on: {{ [("mysql", ACTIVATE_MYSQL)]|list_if }}

--- a/tutornotes/patches/local-docker-compose-services
+++ b/tutornotes/patches/local-docker-compose-services
@@ -7,5 +7,4 @@ notes:
     - ../plugins/notes/apps/settings/tutor.py:/openedx/edx-notes-api/notesserver/settings/tutor.py:ro
     - ../../data/notes:/openedx/data
   restart: unless-stopped
-  depends_on:
-    - mysql
+  depends_on: {{ [("mysql", ACTIVATE_MYSQL)]|list_if }}


### PR DESCRIPTION
This was recently fixed in tutor by
https://github.com/overhangio/tutor/pull/359. This PR maintains parity.

@regisb @LucGranato 