### PR TITLE
fix: actually enable student notes in the lms/cms!

### DIFF
--- a/tutornotes/patches/common-env-features
+++ b/tutornotes/patches/common-env-features
@@ -1,0 +1,1 @@
+"ENABLE_EDXNOTES": true


### PR DESCRIPTION
I have no idea why this patch was removed in the first place...

See:
https://discuss.overhang.io/t/enable-student-notes-not-visible/2489