### PR TITLE
feat: open stdin & allocate tty on dev services

### DIFF
--- a/tutornotes/patches/local-docker-compose-dev-services
+++ b/tutornotes/patches/local-docker-compose-dev-services
@@ -2,3 +2,5 @@ notes:
   command: ./manage.py runserver 0.0.0.0:8120
   ports:
     - "8120:8120"
+  stdin_open: true
+  tty: true


### PR DESCRIPTION
This ensures that services started with `tutor dev start`
are as capable for breakpoint debugging, et al, as services
started with `tutor dev runserver` are. We plan to remove
`tutor dev runserver`.

Blocks https://github.com/overhangio/tutor/pull/644