### PR TITLE
feat: add COMPOSE_MOUNTS for edx-notes-api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,4 +43,4 @@ To debug the notes API service, you are encouraged to mount the edx-notes-api re
 
     tutor dev start --mount /path/to/edx-notes-api
 
-Feel free to add breakpoints (``import pdb; pdb.set_trace()``) anywhere in your source code to debug your application.
+Feel free to add breakpoints (``breakpoint()``) anywhere in your source code to debug your application.

--- a/README.rst
+++ b/README.rst
@@ -35,3 +35,12 @@ Configuration
 - ``NOTES_MYSQL_USERNAME`` (default: ``"notes"``)
 
 These values can be modified with ``tutor config save --set PARAM_NAME=VALUE`` commands.
+
+Debugging
+---------
+
+To debug the notes API service, you are encouraged to mount the edx-notes-api repo from the host in the development container:
+
+    tutor dev start --mount /path/to/edx-notes-api
+
+Feel free to add breakpoints (``import pdb; pdb.set_trace()``) anywhere in your source code to debug your application.

--- a/tutornotes/plugin.py
+++ b/tutornotes/plugin.py
@@ -53,6 +53,20 @@ tutor_hooks.Filters.IMAGES_PUSH.add_item((
     "{{ NOTES_DOCKER_IMAGE }}",
 ))
 
+@tutor_hooks.Filters.COMPOSE_MOUNTS.add()
+def _mount_edx_notes_api(volumes, name):
+    """
+    When mounting cs_comments_service with `--mount=/path/to/edx-notes-api`,
+    bind-mount the host repo in the notes container.
+    """
+    if name == "edx-notes-api":
+        path = "/app/edx-notes-api"
+        volumes += [
+            ("notes", path),
+            ("notes-job", path),
+        ]
+    return volumes
+
 ####### Boilerplate code
 # Add the "templates" folder as a template root
 tutor_hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(

--- a/tutornotes/plugin.py
+++ b/tutornotes/plugin.py
@@ -56,7 +56,7 @@ tutor_hooks.Filters.IMAGES_PUSH.add_item((
 @tutor_hooks.Filters.COMPOSE_MOUNTS.add()
 def _mount_edx_notes_api(volumes, name):
     """
-    When mounting cs_comments_service with `--mount=/path/to/edx-notes-api`,
+    When mounting edx-notes-api with `--mount=/path/to/edx-notes-api`,
     bind-mount the host repo in the notes container.
     """
     if name == "edx-notes-api":


### PR DESCRIPTION
Part of https://github.com/overhangio/2u-tutor-adoption/issues/26

In order to remove `runserver`, the following must be done for all official tutor plugins:

- [X] Ensure that the plugin is ported to the V1 API
- [ ] Ensure that the plugin hooks into the COMPOSE_MOUNTS filter in order to automatically bind-mount folders as appropriate.
- [X] Replace any references to runserver with start
- [X] Replace any references to the --volume option with an equivalent usage of the --mount option.

Within this repo, there was only one incomplete task: 'Ensure that the plugin hooks into the `COMPOSE_MOUNTS` filter in order to automatically bind-mount folders as appropriate.'. This task is solved with this PR.

A `COMPOSE_MOUNTS` function has been added to easily mount
`edx-notes-api` to `/app/edx-notes-api`

It was tested by installing the plugin and mounting a local `edx-notes-api` via `tutor dev run notes --mount=/path/to/edx-notes-api bash`, and checking that files changed or created within the container's bash shell could be found in the local `edx-notes-api` directory, and vice versa.

