### PR TITLE
fix: specify elasticsearch scheme

### DIFF
--- a/tutornotes/templates/notes/apps/settings/tutor.py
+++ b/tutornotes/templates/notes/apps/settings/tutor.py
@@ -23,7 +23,11 @@ DATABASES = {
 CLIENT_ID = "notes"
 CLIENT_SECRET = "{{ NOTES_OAUTH2_SECRET }}"
 
-ELASTICSEARCH_DSL = {'default': {'hosts': '{{ ELASTICSEARCH_HOST }}:{{ ELASTICSEARCH_PORT }}'}}
+ELASTICSEARCH_DSL = {
+    'default': {
+        'hosts': '{{ ELASTICSEARCH_SCHEME }}://{{ ELASTICSEARCH_HOST }}:{{ ELASTICSEARCH_PORT }}'
+    }
+}
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
Add `ELASTICSEARCH_SCHEME` to `ELASTICSEARCH_DSL` to avoid an error when ES is implemented with SSL