### PR TITLE
feat: allowing customization of notes repo and version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,8 @@ Configuration
 - ``NOTES_HOST`` (default: ``"notes.{{ LMS_HOST }}"``)
 - ``NOTES_MYSQL_DATABASE`` (default: ``"notes"``)
 - ``NOTES_MYSQL_USERNAME`` (default: ``"notes"``)
+- ``NOTES_CODE_REPO`` (default: ``"https://github.com/edx/edx-notes-api"``)
+- ``NOTES_CODE_VERSION`` (default: ``"{{ OPENEDX_COMMON_VERSION }}"``)
 
 These values can be modified with ``tutor config save --set PARAM_NAME=VALUE`` commands.
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Students notes plugin for `Tutor <https://docs.tutor.overhang.io>`_
 ===================================================================
 
-This is a plugin for `Tutor <https://docs.tutor.overhang.io>`_ to easily add the `Open edX note-taking app <https://github.com/edx/edx-notes-api>`_ to an Open edX platform. This app allows students to annotate portions of the courseware (see `the official documentation <https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-olive.master/exercises_tools/notes.html>`_).
+This is a plugin for `Tutor <https://docs.tutor.overhang.io>`_ to easily add the `Open edX note-taking app <https://github.com/openedx/edx-notes-api>`_ to an Open edX platform. This app allows students to annotate portions of the courseware (see `the official documentation <https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-olive.master/exercises_tools/notes.html>`_).
 
 .. image:: https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-olive.master/_images/SFD_SN_bodyexample.png
     :alt: Notes in action
@@ -33,8 +33,8 @@ Configuration
 - ``NOTES_HOST`` (default: ``"notes.{{ LMS_HOST }}"``)
 - ``NOTES_MYSQL_DATABASE`` (default: ``"notes"``)
 - ``NOTES_MYSQL_USERNAME`` (default: ``"notes"``)
-- ``NOTES_CODE_REPO`` (default: ``"https://github.com/edx/edx-notes-api"``)
-- ``NOTES_CODE_VERSION`` (default: ``"{{ OPENEDX_COMMON_VERSION }}"``)
+- ``NOTES_REPOSITORY`` (default: ``"https://github.com/openedx/edx-notes-api"``)
+- ``NOTES_REPOSITORY_VERSION`` (default: ``"{{ OPENEDX_COMMON_VERSION }}"``)
 
 These values can be modified with ``tutor config save --set PARAM_NAME=VALUE`` commands.
 

--- a/tutornotes/plugin.py
+++ b/tutornotes/plugin.py
@@ -20,6 +20,8 @@ config = {
         "HOST": "notes.{{ LMS_HOST }}",
         "MYSQL_DATABASE": "notes",
         "MYSQL_USERNAME": "notes",
+        "CODE_REPO": "https://github.com/edx/edx-notes-api",
+        "CODE_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
     },
 }
 

--- a/tutornotes/plugin.py
+++ b/tutornotes/plugin.py
@@ -20,8 +20,8 @@ config = {
         "HOST": "notes.{{ LMS_HOST }}",
         "MYSQL_DATABASE": "notes",
         "MYSQL_USERNAME": "notes",
-        "CODE_REPO": "https://github.com/edx/edx-notes-api",
-        "CODE_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
+        "REPOSITORY": "https://github.com/openedx/edx-notes-api",
+        "REPOSITORY_VERSION": "{{ OPENEDX_COMMON_VERSION }}",
     },
 }
 

--- a/tutornotes/templates/notes/build/notes/Dockerfile
+++ b/tutornotes/templates/notes/build/notes/Dockerfile
@@ -10,7 +10,7 @@ ARG APP_USER_ID=1000
 RUN useradd --home-dir /app --create-home --shell /bin/bash --uid ${APP_USER_ID} app
 USER ${APP_USER_ID}
 
-RUN git clone {{ NOTES_CODE_REPO }} --branch {{ NOTES_CODE_VERSION }} --depth 1 /app/edx-notes-api
+RUN git clone {{ NOTES_REPOSITORY }} --branch {{ NOTES_REPOSITORY_VERSION }} --depth 1 /app/edx-notes-api
 WORKDIR /app/edx-notes-api
 
 RUN python -m venv /app/venv

--- a/tutornotes/templates/notes/build/notes/Dockerfile
+++ b/tutornotes/templates/notes/build/notes/Dockerfile
@@ -10,7 +10,7 @@ ARG APP_USER_ID=1000
 RUN useradd --home-dir /app --create-home --shell /bin/bash --uid ${APP_USER_ID} app
 USER ${APP_USER_ID}
 
-RUN git clone https://github.com/edx/edx-notes-api --branch {{ OPENEDX_COMMON_VERSION }} --depth 1 /app/edx-notes-api
+RUN git clone {{ NOTES_CODE_REPO }} --branch {{ NOTES_CODE_VERSION }} --depth 1 /app/edx-notes-api
 WORKDIR /app/edx-notes-api
 
 RUN python -m venv /app/venv


### PR DESCRIPTION
This PR adds 2 new configurations for the plugins:

**NOTES_REPOSITORY**: (default: "https://github.com/openedx/edx-notes-api")
**NOTES_REPOSITORY_VERSION**: (default: "{{ OPENEDX_COMMON_VERSION }}")

These will allow setting custom notes code repository and notes code version to build the image, which enables adding custom features for notes service on top of the default upstream version.