### PR TITLE
fix: internal api port number

### DIFF
--- a/tutornotes/patches/openedx-lms-common-settings
+++ b/tutornotes/patches/openedx-lms-common-settings
@@ -1,3 +1,2 @@
 # Student notes
 EDXNOTES_CLIENT_NAME = "notes"
-EDXNOTES_INTERNAL_API = "http://notes:8000/api/v1"

--- a/tutornotes/patches/openedx-lms-development-settings
+++ b/tutornotes/patches/openedx-lms-development-settings
@@ -1,1 +1,2 @@
 EDXNOTES_PUBLIC_API = "http://{{ NOTES_HOST }}:8120/api/v1"
+EDXNOTES_INTERNAL_API = "http://notes:8120/api/v1"

--- a/tutornotes/patches/openedx-lms-production-settings
+++ b/tutornotes/patches/openedx-lms-production-settings
@@ -1,1 +1,2 @@
 EDXNOTES_PUBLIC_API = "{{ "https" if ENABLE_HTTPS else "http" }}://{{ NOTES_HOST }}/api/v1"
+EDXNOTES_INTERNAL_API = "http://notes:8000/api/v1"


### PR DESCRIPTION
The API is running in port `8120` in development but current `EDXNOTES_INTERNAL_API` setting points to `8000`, which leads to below error when navigating to `Notes` tab in LMS.

![image](https://user-images.githubusercontent.com/10894099/220918411-ece686bc-598f-4212-9c35-e7910fb60fa6.png)