### PR TITLE
fix: build elasticsearch index during initialization

### DIFF
--- a/tutornotes/templates/notes/tasks/notes/init
+++ b/tutornotes/templates/notes/tasks/notes/init
@@ -1,1 +1,2 @@
 ./manage.py migrate
+./manage.py search_index --rebuild -f


### PR DESCRIPTION
The elasticsearch index needs to be created on initialization else notes search functionality does not work.