### PR TITLE
chore: remove notes permissions container.

### DIFF
--- a/changelog.d/20230731_075900_jhony.avella_remove_permissions_container.md
+++ b/changelog.d/20230731_075900_jhony.avella_remove_permissions_container.md
@@ -1,0 +1,1 @@
+- [Improvement] Removing the notes permissions container in favor of a global single permissions container. (by @jfavellar90)

--- a/tutornotes/patches/local-docker-compose-permissions-command
+++ b/tutornotes/patches/local-docker-compose-permissions-command
@@ -1,0 +1,1 @@
+setowner 1000 /mounts/notes

--- a/tutornotes/patches/local-docker-compose-permissions-volumes
+++ b/tutornotes/patches/local-docker-compose-permissions-volumes
@@ -1,0 +1,1 @@
+- ../../data/notes:/mounts/notes

--- a/tutornotes/patches/local-docker-compose-services
+++ b/tutornotes/patches/local-docker-compose-services
@@ -8,12 +8,4 @@ notes:
     - ../../data/notes:/app/data
   restart: unless-stopped
   depends_on:
-    - notes-permissions
     {% if RUN_MYSQL %}- mysql{% endif %}
-
-notes-permissions:
-  image: {{ DOCKER_IMAGE_PERMISSIONS }}
-  command: ["1000", "/app/notes"]
-  restart: on-failure
-  volumes:
-    - ../../data/notes:/app/notes

--- a/tutornotes/patches/local-docker-compose-services
+++ b/tutornotes/patches/local-docker-compose-services
@@ -7,5 +7,4 @@ notes:
     - ../plugins/notes/apps/settings/tutor.py:/app/edx-notes-api/notesserver/settings/tutor.py:ro
     - ../../data/notes:/app/data
   restart: unless-stopped
-  depends_on:
-    {% if RUN_MYSQL %}- mysql{% endif %}
+  depends_on: {{ [("mysql", RUN_MYSQL)]|list_if }}


### PR DESCRIPTION
There is now a single "permissions" container that makes all permission changes in the Tutor core. See this commit for reference: https://github.com/overhangio/tutor/commit/bfa1f657282d53f8a9c1820ebcb27d630836ac58