### PR TITLE
fix: broken feature in dev mode

### DIFF
--- a/changelog.d/20241114_112459_regis_fix_dev_cors.md
+++ b/changelog.d/20241114_112459_regis_fix_dev_cors.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix broken feature in `dev` mode, where the frontend is reporting a CORS error on loading the notes. (by @regisb)

--- a/tutornotes/templates/notes/apps/settings/tutor.py
+++ b/tutornotes/templates/notes/apps/settings/tutor.py
@@ -4,6 +4,7 @@ SECRET_KEY = "{{ NOTES_SECRET_KEY }}"
 ALLOWED_HOSTS = [
     "notes",
     "{{ NOTES_HOST }}",
+    "{{ NOTES_HOST }}:8120",
 ]
 
 DATABASES = {


### PR DESCRIPTION
Student notes were simply not working in dev mode because the dev server hostname was not whitelisted in ALLOWED_HOSTS.